### PR TITLE
No need to ksort user specified list of modules

### DIFF
--- a/EMigrateCommand.php
+++ b/EMigrateCommand.php
@@ -355,7 +355,6 @@ class EMigrateCommand extends MigrateCommand
 		}
 		$this->_scopeNewMigrations = false;
 
-		ksort($migrations);
 		return array_values($migrations);
 	}
 


### PR DESCRIPTION
Why? Because many sql tables use foregin keys, and the first will need to install each module individually now (for sort order - create tables with foregin keys) instead user-specified list of modules in command
