### PR TITLE
check existance of migration path, continue if not found

### DIFF
--- a/EMigrateCommand.php
+++ b/EMigrateCommand.php
@@ -345,6 +345,7 @@ class EMigrateCommand extends MigrateCommand
 		foreach($this->_runModulePaths as $module => $path)
 		{
 			$this->migrationPath = Yii::getPathOfAlias($path);
+			if (!is_dir($this->migrationPath)) continue;
 			foreach(parent::getNewMigrations() as $migration) {
 				if ($this->_scopeAddModule) {
 					$migrations[$migration] = $module.$this->moduleDelimiter.$migration;


### PR DESCRIPTION
If a migration is not found, don't throw a PHP error, but continue with the rest of configured paths.
