### PR TITLE
Update EMigrateCommand.php

### DIFF
--- a/EMigrateCommand.php
+++ b/EMigrateCommand.php
@@ -343,14 +343,16 @@ class EMigrateCommand extends MigrateCommand
 		$this->_scopeNewMigrations = true;
 		$migrations = array();
 		// get new migrations for all new modules
-		foreach($this->_runModulePaths as $module => $path)
-		{
-			$this->migrationPath = Yii::getPathOfAlias($path);
-			foreach(parent::getNewMigrations() as $migration) {
-				if ($this->_scopeAddModule) {
-					$migrations[$migration] = $module.$this->moduleDelimiter.$migration;
-				} else {
-					$migrations[$migration] = $migration;
+		if (!is_null($this->_runModulePaths)) {
+			foreach($this->_runModulePaths as $module => $path)
+			{
+				$this->migrationPath = Yii::getPathOfAlias($path);
+				foreach(parent::getNewMigrations() as $migration) {
+					if ($this->_scopeAddModule) {
+						$migrations[$migration] = $module.$this->moduleDelimiter.$migration;
+					} else {
+						$migrations[$migration] = $migration;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
"_runModulePaths" is null by default. If there is no modules, included for collecting migrations, you will see a error "PHP Error[2]: Invalid argument supplied for foreach()"
